### PR TITLE
refactor(core): remove `use strict` from es6 source files

### DIFF
--- a/packages/backbrace-core/src/backbrace.js
+++ b/packages/backbrace-core/src/backbrace.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Backbrace public api.
  * @module backbrace

--- a/packages/backbrace-core/src/jss.js
+++ b/packages/backbrace-core/src/jss.js
@@ -3,7 +3,6 @@
  * @module jss
  * @private
  */
-'use strict';
 
 import { settings } from './settings';
 

--- a/packages/backbrace-core/src/sanitize.js
+++ b/packages/backbrace-core/src/sanitize.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *     Any commits to this file should be reviewed with security in mind.  *
  *   Changes to this file can potentially create security vulnerabilities. *

--- a/packages/backbrace-core/src/sweetalert.js
+++ b/packages/backbrace-core/src/sweetalert.js
@@ -3,7 +3,6 @@
  * @module sweetalert
  * @private
  */
-'use strict';
 
 import { width } from './util';
 import { get as getSwal } from './providers/swal';

--- a/packages/backbrace-core/src/util.js
+++ b/packages/backbrace-core/src/util.js
@@ -3,7 +3,6 @@
  * @module util
  * @private
  */
-'use strict';
 
 import { get as getJQuery } from './providers/jquery';
 import { get as getWindow } from './providers/window';


### PR DESCRIPTION
ES6 modules are always run in strict mode.

(see https://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code)