### PR TITLE
build(grunt): fix typings errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
           'packages/backbrace-core/src/components/*/*.js',
           'packages/backbrace-core/src/backbrace.js',
           'packages/backbrace-core/src/app.js',
-          'packages/backbrace-core/src/code.js',
+          'packages/backbrace-core/src/promises.js',
           'packages/backbrace-core/src/controller.js',
           'packages/backbrace-core/src/log.js'
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -735,9 +735,9 @@
       }
     },
     "@backbrace/dts-generator": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@backbrace/dts-generator/-/dts-generator-0.1.0-beta.1.tgz",
-      "integrity": "sha512-yj0qjoWoGm+na+WaGxdQtEqVIOAHbWj8w7ViQunvxrmfbMFgrb8dhAg/SRL8rQ61qS1Rw4wEr3hZxFJLxY1KrA==",
+      "version": "0.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@backbrace/dts-generator/-/dts-generator-0.1.0-beta.2.tgz",
+      "integrity": "sha512-ylwpI7jADkJXyxIvmV0nUIwwcX5cOO2EFfLWXWeW/74rBrnFFHm9Hv++ep2S4o/56bpCeoMsIrope1xc4IgdWA==",
       "dev": true,
       "requires": {
         "dts-dom": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/runtime": "^7.1.2",
-    "@backbrace/dts-generator": "^0.1.0-beta.1",
+    "@backbrace/dts-generator": "0.1.0-beta.2",
     "@types/ace": "^0.0.40",
     "@types/jasmine": "^2.8.9",
     "@types/jquery": "^3.3.22",

--- a/packages/backbrace-core/src/app.js
+++ b/packages/backbrace-core/src/app.js
@@ -78,7 +78,7 @@ function onTick() {
  * @method message
  * @memberof module:backbrace
  * @param {string} msg Message to display.
- * @param {function()} [callbackFn] Callback function to execute after the dialog is dismissed.
+ * @param {function():void} [callbackFn] Callback function to execute after the dialog is dismissed.
  * @param {string} [title="Application Message"] Title of the dialog.
  * @returns {void}
  */
@@ -102,7 +102,7 @@ export function message(msg, callbackFn, title) {
  * Show a confirmation dialog.
  * @ignore
  * @param {string} msg Message to display.
- * @param {function(boolean)} callbackFn Callback function to execute after the dialog is dismissed.
+ * @param {function(boolean):void} callbackFn Callback function to execute after the dialog is dismissed.
  * @param {string} [title="Application Confirmation"] Title of the dialog.
  * @param {string} [yescaption="OK"] Caption of the "yes" button.
  * @param {string} [nocaption="Cancel"] Caption of the "no" button.

--- a/packages/backbrace-core/src/classes/promisequeue.js
+++ b/packages/backbrace-core/src/classes/promisequeue.js
@@ -11,7 +11,7 @@ export class PromiseQueue {
 
     /**
      * @constructor
-     * @param {function()} func Queue function to execute.
+     * @param {function():*} func Queue function to execute.
      */
     constructor(func) {
         /**
@@ -21,7 +21,7 @@ export class PromiseQueue {
          */
         this.id = uid();
         /**
-         * @type {function()}
+         * @type {function():*}
          * @description
          * Function to execute.
          */
@@ -33,7 +33,7 @@ export class PromiseQueue {
          */
         this.queue = [];
         /**
-         * @type {function()}
+         * @type {function():*}
          * @description
          * Function that is currently executing.
          */
@@ -125,7 +125,7 @@ export class PromiseQueue {
     /**
      * @description
      * Run the promise queue.
-     * @param {function()} callback Callback function to run.
+     * @param {function():void} callback Callback function to run.
      * @returns {void}
      */
     run(callback) {

--- a/packages/backbrace-core/src/components/action.js
+++ b/packages/backbrace-core/src/components/action.js
@@ -29,7 +29,7 @@ export class ActionComponent extends Component {
         /**
          * @description
          * Function to run on click.
-         * @type {function()}
+         * @type {ActionRunnerOnClick}
          */
         this.onclick = null;
 
@@ -72,7 +72,7 @@ export class ActionComponent extends Component {
     /**
      * @description
      * Set the on click function.
-     * @param {function()} func On click function.
+     * @param {ActionRunnerOnClick} func On click function.
      * @returns {ActionComponent} Returns itself for chaining.
      */
     click(func) {

--- a/packages/backbrace-core/src/components/pagecomponents/listpage.js
+++ b/packages/backbrace-core/src/components/pagecomponents/listpage.js
@@ -89,7 +89,7 @@ export class ListPageComponent extends PageComponent {
          * @ignore
          * @description
          * On key press event handler for cell editors.
-         * @param {Event} ev Key press event.
+         * @param {JQuery.Event} ev Key press event.
          * @returns {boolean} Returns `false` to cancel bubbling.
          */
         function onKeyPress(ev) {

--- a/packages/backbrace-core/src/jss.js
+++ b/packages/backbrace-core/src/jss.js
@@ -10,7 +10,7 @@ import { settings } from './settings';
  * Iterate through an object.
  * @private
  * @param {object} obj Object to iterate through.
- * @param {function(*,Key,object)} iterator Iterator function to call.
+ * @param {function(*,Key,object):void} iterator Iterator function to call.
  * @param {*} [context] Context to run the iterator function.
  * @returns {void}
  */

--- a/packages/backbrace-core/src/promises.js
+++ b/packages/backbrace-core/src/promises.js
@@ -73,7 +73,7 @@ function runNextQueue() {
  * Each function will be run in order.
  *
  * @param {...GenericFunction} args Functions to run.
- * @returns {JQueryPromise} Promise to run the functions.
+ * @returns {JQueryPromise<any>} Promise to run the functions.
  * @example
  * return backbrace.promiseblock(
  *  function() {
@@ -121,9 +121,9 @@ export function promiseinsert(...args) {
  * Loop through an array using `promiseblock`.
  * @template T
  * @param {ArrayLike<T>} obj Object to iterate through.
- * @param {function(T,Key,ArrayLike<T>)} iterator Iterator function to call.
+ * @param {function(T,Key,ArrayLike<T>):(void|JQueryPromise<any>)} iterator Iterator function to call.
  * @param {*} [context] Context to run the iterator function.
- * @returns {JQueryPromise} Promise to return after we are done looping.
+ * @returns {JQueryPromise<any>} Promise to return after we are done looping.
  */
 export function promiseeach(obj, iterator, context) {
 

--- a/packages/backbrace-core/src/types.js
+++ b/packages/backbrace-core/src/types.js
@@ -68,6 +68,11 @@
  */
 
 /**
+ * @callback ActionRunnerOnClick
+ * @returns {(void|JQueryPromise<any>)}
+ */
+
+/**
  * Alert instance.
  * @typedef {object} AlertInstance
  * @property {AlertInstanceMessage} message Show a message box.

--- a/packages/backbrace-core/src/util.js
+++ b/packages/backbrace-core/src/util.js
@@ -165,7 +165,7 @@ export function merge(dst) {
  * @internal
  * @template T
  * @param {ArrayLike<T>} obj Object to iterate through.
- * @param {function(T,Key,ArrayLike<T>)} iterator Iterator function to call.
+ * @param {function(T,Key,ArrayLike<T>):void} iterator Iterator function to call.
  * @param {*} [context] Context to run the iterator function.
  * @returns {ArrayLike<T>} Returned object for chaining.
  */


### PR DESCRIPTION
Several typing errors have shown up in the newest version of VS Code (1.30.0 Insider).

`Function type, which lacks return-type annotation, implicitly has an 'any' return type.`

We need to specify return types for these `function` types.

Also, the promise queue typings are not being generated with `grunt typings`.