### PR TITLE
fix(core): use `rest` operator in `formatString` function

### DIFF
--- a/packages/backbrace-core/src/error.js
+++ b/packages/backbrace-core/src/error.js
@@ -15,7 +15,7 @@ import { isDevMode, formatString } from './util';
 export function error(scope, ErrorClass) {
     ErrorClass = ErrorClass || Error;
     return function(code, message, ...args) {
-        let errMessage = (isDevMode() ? '[' + (scope ? scope + ':' : '') + code + '] ' : '') + formatString(message, args);
+        let errMessage = (isDevMode() ? '[' + (scope ? scope + ':' : '') + code + '] ' : '') + formatString(message, ...args);
         return new ErrorClass(errMessage);
     };
 }

--- a/packages/backbrace-core/src/util.js
+++ b/packages/backbrace-core/src/util.js
@@ -96,16 +96,16 @@ export function isDate(val) {
  * @method formatString
  * @memberof module:backbrace
  * @param {string} str String to format.
+ * @param {...*} args Arguments to merge into the string.
  * @returns {string} Formatted string.
  * @example
  * var str = backbrace.formatString('This is a {0} {1}.','test','message');
  * // str = 'This is a test message'
  */
-export function formatString(str) {
-  const a = arguments;
+export function formatString(str, ...args) {
   return str.replace(/{(\d+)}/g, function(match, number) {
-    return typeof a[+number + 1] !== 'undefined'
-      ? a[+number + 1] : '';
+    return typeof args[+number] !== 'undefined'
+      ? args[+number] : '';
   });
 }
 


### PR DESCRIPTION
Using the `rest` operator allows us to easily pass in the `rest` arguments into the `formatString` function (ie. in the `error` function)